### PR TITLE
xkeyboard-config 2.44

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: http://www.x.org/releases/individual/data/xkeyboard-config/xkeyboard-config-{{ version }}.tar.xz
+  url: https://www.x.org/releases/individual/data/xkeyboard-config/xkeyboard-config-{{ version }}.tar.xz
   sha256: 54d2c33eeebb031d48fa590c543e54c9bcbd0f00386ebc6489b2f47a0da4342a
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ stdlib('c') }}
     - meson
     - make
   host:
@@ -38,7 +37,7 @@ about:
     System implementations (free, open source and commercial).
     The project is targeted to XKB-based systems.
   doc_url: https://www.freedesktop.org/wiki/Software/XKeyboardConfig/
-  dev_url: https://www.freedesktop.org/wiki/Software/XKeyboardConfig/Development/
+  dev_url: https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,11 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    # Perl is required implicitly:
+    # $BUILD_PREFIX/bin/meson --internal exe --capture rules/base.lst -- $SRC_DIR/rules/xml2lst.pl rules/base.xml
+    # /usr/bin/env: perl: No such file or directory
+    # see https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/blob/xkeyboard-config-2.44/rules/meson.build?ref_type=tags#L165
+    - perl
     - meson
     - make
   host:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-8137](https://anaconda.atlassian.net/browse/PKG-8137) 
- [Upstream repository](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/tree/xkeyboard-config-2.44?ref_type=tags)

### Explanation of changes:

- Add `perl` because it's is required implicitly, see https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/blob/xkeyboard-config-2.44/rules/meson.build?ref_type=tags#L165:
```
    $BUILD_PREFIX/bin/meson --internal exe --capture rules/base.lst -- $SRC_DIR/rules/xml2lst.pl rules/base.xml
    /usr/bin/env: perl: No such file or directory
```
- Fix source url with HTTPS
- Update dev_url

### Notes:

-

[PKG-8137]: https://anaconda.atlassian.net/browse/PKG-8137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ