### PR TITLE
Build on osx too.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     # Perl is required implicitly:
     # $BUILD_PREFIX/bin/meson --internal exe --capture rules/base.lst -- $SRC_DIR/rules/xml2lst.pl rules/base.xml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,8 @@ source:
   sha256: 54d2c33eeebb031d48fa590c543e54c9bcbd0f00386ebc6489b2f47a0da4342a
 
 build:
-  number: 0
-  skip: true  # [not linux]
+  number: 1
+  skip: true  # [win]
 
 requirements:
   build:
@@ -22,6 +22,7 @@ requirements:
     - perl
     - meson
     - make
+    - gawk  # [osx]
   host:
     - xorg-xorgproto
     - xorg-libx11


### PR DESCRIPTION
xkeyboard-config rebuild

**Destination channel:**  defaults

### Links

- [Upstream repository](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/tree/xkeyboard-config-2.44?ref_type=tags)
- [PKG-11674](https://anaconda.atlassian.net/browse/PKG-11674)

### Explanation of changes:

- Build for osx
- Add `gawk` for osx only
- Add stdlib


[PKG-11674]: https://anaconda.atlassian.net/browse/PKG-11674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ